### PR TITLE
fix for "the JSON object must be str, not 'bytes' error message"

### DIFF
--- a/todoist-progressbar.py
+++ b/todoist-progressbar.py
@@ -182,7 +182,7 @@ try:
     urllib.request.urlopen(request)
     
     update_releaseinforaw = urllib.request.urlopen(config.update_url).read()
-    json = json.loads(update_releaseinforaw)
+    json = json.loads(update_releaseinforaw.decode('utf-8'))
     
     if not config.version == json[0]['tag_name']:
         print("\n#########\n")


### PR DESCRIPTION
Hi,

without this change I always got the following traceback when running the script:

```
Traceback (most recent call last):
  File "todoist-progressbar.py", line 185, in <module>
    json = json.loads(update_releaseinforaw)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```